### PR TITLE
Request randomly generated ID when creating item with no set ID

### DIFF
--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -102,15 +103,15 @@ class DatalabClient(BaseDatalabClient):
 
     def create_item(
         self,
-        item_id: str,
-        item_type: str,
-        item_data: Optional[dict[str, Any]] = None,
-        collection_id: Optional[str] = None,
+        item_id: str | None = None,
+        item_type: str = "samples",
+        item_data: dict[str, Any] | None = None,
+        collection_id: str | None = None,
     ) -> dict[str, Any]:
         """Create an item with a given ID and item data.
 
         Parameters:
-            item_id: The ID of the item to create.
+            item_id: The ID of the item to create, if set to `None`, the server will generate one.
             item_type: The type of item to create, e.g., 'samples', 'cells'.
             item_data: The data for the item.
             collection_id: The ID of the collection to add the item to (optional).
@@ -133,7 +134,7 @@ class DatalabClient(BaseDatalabClient):
         create_item_url = f"{self.datalab_api_url}/new-sample/"
         create_item_resp = self.session.post(
             create_item_url,
-            json=new_item,
+            json={"new_sample_data": new_item, "generate_id_automatically": item_id is None},
             follow_redirects=True,
         )
         try:

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -47,7 +48,7 @@ class DatalabClient(BaseDatalabClient):
             )
         return user_resp.json()
 
-    def get_items(self, item_type: Optional[str] = "samples") -> list[dict[str, Any]]:
+    def get_items(self, item_type: str | None = "samples") -> list[dict[str, Any]]:
         """List items of the given type available to the authenticated user.
 
         Parameters:
@@ -72,7 +73,7 @@ class DatalabClient(BaseDatalabClient):
         return items[item_type]
 
     def search_items(
-        self, query: str, item_types: Union[Iterable[str], str] = ("samples", "cells")
+        self, query: str, item_types: Iterable[str] | str = ("samples", "cells")
     ) -> list[dict[str, Any]]:
         """Search for items of the given types that match the query.
 
@@ -183,8 +184,8 @@ class DatalabClient(BaseDatalabClient):
 
     def get_item(
         self,
-        item_id: Optional[str] = None,
-        refcode: Optional[str] = None,
+        item_id: str | None = None,
+        refcode: str | None = None,
         load_blocks: bool = False,
     ) -> dict[str, Any]:
         """Get an item with a given ID or refcode.
@@ -288,7 +289,7 @@ class DatalabClient(BaseDatalabClient):
             raise RuntimeError(f"Failed to get block at {block_url}: {block['status']!r}.")
         return block["new_block_data"]
 
-    def upload_file(self, item_id: str, file_path: Union[Path, str]) -> dict[str, Any]:
+    def upload_file(self, item_id: str, file_path: Path | str) -> dict[str, Any]:
         """Upload a file to an item with a given ID.
 
         Parameters:
@@ -328,8 +329,8 @@ class DatalabClient(BaseDatalabClient):
         self,
         item_id: str,
         block_type: str,
-        file_ids: Optional[Union[str, list[str]]] = None,
-        file_paths: Optional[Union[Path, list[Path]]] = None,
+        file_ids: str | list[str] | None = None,
+        file_paths: Path | list[Path] | None = None,
     ) -> dict[str, Any]:
         """Creates a data block for an item with the given block type and file ID.
 
@@ -386,7 +387,7 @@ class DatalabClient(BaseDatalabClient):
         return block_data
 
     def _update_data_block(
-        self, block_type: str, block_data: dict, file_ids: Optional[Union[str, list[str]]] = None
+        self, block_type: str, block_data: dict, file_ids: str | list[str] | None = None
     ) -> dict[str, Any]:
         """Attaches files to blocks: should only be used via wrapper methods."""
         if file_ids and isinstance(file_ids, str):
@@ -437,7 +438,7 @@ class DatalabClient(BaseDatalabClient):
         return collection["data"]
 
     def create_collection(
-        self, collection_id: str, collection_data: Optional[dict] = None
+        self, collection_id: str, collection_data: dict | None = None
     ) -> dict[str, Any]:
         """Create a collection with a given ID and collection data.
 


### PR DESCRIPTION
When creating an item, you no longer have to specify an `item_id`, the server will generate a random ID in that case.