### PR TITLE
Jdb/item route fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,10 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Sublime settings
+*.sublime-project
+*.sublime-workspace
+
 # Rope project settings
 .ropeproject
 

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -85,7 +85,7 @@ class DatalabClient(BaseDatalabClient):
         """
         if item_type is None:
             item_type = "samples"
-        items_url = f"{self.datalab_api_url}/{item_type}"
+        items_url = f"{self.datalab_api_url}/samples/?type={item_type}"
         items_resp = self.session.get(items_url, follow_redirects=True)
         if items_resp.status_code != 200:
             raise RuntimeError(


### PR DESCRIPTION
The route used by the `get_items` method was previously wrong, except when `item_type="samples"`.

Incidentally, the core datalab api is confusing in this regard, as all the items are under the `samples/` route. 