### PR TITLE
Only install bokeh if not running via emscripten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.x"
+          version: "0.6.x"
           enable-cache: true
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.x"
+          version: "0.6.x"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   PUBLISH_UPDATE_BRANCH: main
   GIT_USER_NAME: datalab developers
-  GIT_USER_EMAIL: "datalab@odbx.science"
+  GIT_USER_EMAIL: "dev@datalab-org.io"
 
 jobs:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -21,19 +21,19 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.7"
+    rev: "v0.11.0"
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.15.0
     hooks:
       - id: mypy

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,15 +6,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - cli
-
-mkdocs:
-  configuration: ./mkdocs.yml
-  fail_on_warning: false
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv sync --all-extras --dev
+    - uv pip install .
+    - .venv/bin/mkdocs build --site-dir $READTHEDOCS_OUTPUT/html

--- a/docs/examples/client_example.ipynb
+++ b/docs/examples/client_example.ipynb
@@ -40,6 +40,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
     "os.environ[\"DATALAB_API_KEY\"] = \"FRWwHSTLocXnihBTZOoGbnRUqyHZEtFt\""
    ]
   },
@@ -359,6 +360,7 @@
    ],
    "source": [
     "from bokeh.io import output_notebook\n",
+    "\n",
     "output_notebook()"
    ]
   },
@@ -378,6 +380,7 @@
    "outputs": [],
    "source": [
     "from datalab_api import DatalabClient\n",
+    "\n",
     "client = DatalabClient(\"demo-api.datalab-org.io\")"
    ]
   },
@@ -1634,9 +1637,14 @@
     "from pathlib import Path\n",
     "\n",
     "file_response = client.upload_file(\n",
-    "    item_id=\"test_salt\", \n",
-    "    file_path=Path.cwd().parent.parent.parent / \"datalab\" / \"pydatalab\" / \"example_data\" / \"echem\" / \"jdb11-1_c3_gcpl_5cycles_2V-3p8V_C-24_data_C09.mpr\",\n",
-    "    display=True\n",
+    "    item_id=\"test_salt\",\n",
+    "    file_path=Path.cwd().parent.parent.parent\n",
+    "    / \"datalab\"\n",
+    "    / \"pydatalab\"\n",
+    "    / \"example_data\"\n",
+    "    / \"echem\"\n",
+    "    / \"jdb11-1_c3_gcpl_5cycles_2V-3p8V_C-24_data_C09.mpr\",\n",
+    "    display=True,\n",
     ")\n",
     "file_id = file_response[\"file_id\"]"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,15 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "datalab-api"
 readme = "README.md"
-description = "A Python API for instances of the datalab data management platform (https://github.com/the-grey-group/datalab)."
+description = "A Python API for instances of the datalab data management platform (https://github.com/datalab-org/datalab)."
 keywords = []
 license = { text = "MIT" }
 authors = [{ name = "Matthew Evans", email = "matthew@ml-evs.science" }]
 dynamic = ["version"]
 classifiers = [
-    "Programming Language :: Python :: 3", "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3", "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Intended Audience :: Science/Research",
@@ -22,11 +23,11 @@ classifiers = [
 ]
 
 requires-python = ">=3.9"
-dependencies =[
-    "httpx ~= 0.27", # better HTTP requests
-    "bokeh ~= 2.4",  # interactive plots from datalab directly
-    "rich ~= 13.0",  # nicer terminal output
-    "numpy < 2", # upper pin for numpy due to bad pins in bokeh
+dependencies = [
+    "httpx ~= 0.27",                                 # better HTTP requests
+    'bokeh ~= 2.4; platform_system != "Emscripten"', # interactive plots from datalab directly
+    "rich ~= 13.0",                                  # nicer terminal output
+    "numpy < 2",                                     # upper pin for numpy due to bad pins in bokeh
 ]
 
 
@@ -47,18 +48,13 @@ docs = [
 ]
 
 cli = [
-    "typer ~= 0.9",   # command line interface
+    "typer ~= 0.9",       # command line interface
     "click-shell ~= 2.1", # REPL-like interface
 ]
 
-cheminventory-helper = [
-    "pandas ~= 2.2",
-    "openpyxl ~= 3.0"
-]
+cheminventory-helper = ["pandas ~= 2.2", "openpyxl ~= 3.0"]
 
-all = [
-    "datalab-api[dev,docs,cli]"
-]
+all = ["datalab-api[dev,docs,cli]"]
 
 [project.scripts]
 datalab = "datalab_api.cli:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ ignore = [
     "PLW0603",
     "PLW2901",
     "PT003",
-    "PT004",   # pytest-missing-fixture-name-underscore
     "PT006",   # pytest-parametrize-names-wrong-type
     "PT013",   # pytest-incorrect-pytest-import
     "PTH",     # prefer Pathlib to os.path
@@ -161,7 +160,7 @@ ignore = [
 pydocstyle.convention = "numpy"
 isort.known-first-party = ["jobflow_remote"]
 isort.split-on-trailing-comma = false
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
+fixable = ["A", "B", "C", "D", "E", "F", "I", "PT", "RUF"]
 unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Union
 
 from ._base import BaseDatalabClient, __version__
 
-__all__ = ("__version__", "DatalabClient")
+__all__ = ("DatalabClient", "__version__")
 
 
 class DuplicateItemError(ValueError):

--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -14,7 +14,7 @@ from rich.table import Table
 
 __version__ = version("datalab-api")
 
-__all__ = ("__version__", "BaseDatalabClient")
+__all__ = ("BaseDatalabClient", "__version__")
 
 
 def pretty_displayer(method):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 from pytest import fixture
 
 
-@fixture()
+@fixture
 def fake_ui_html():
     """Returns a mocked HTML response from the Datalab UI that includes a metadata tag for a fake API URL."""
     return """<!doctype html>
@@ -39,7 +39,7 @@ def fake_ui_html():
 </html>"""
 
 
-@fixture()
+@fixture
 def fake_info_json():
     """Returns a mocked JSON response for the API /info endpoint."""
 
@@ -48,7 +48,7 @@ def fake_info_json():
     )
 
 
-@fixture()
+@fixture
 def fake_block_info_json():
     """Returns a mocked JSON response for the API /info endpoint."""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,8 @@
 import pytest
 import respx
-from datalab_api import DatalabClient
 from httpx import Response
+
+from datalab_api import DatalabClient
 
 
 @respx.mock

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -287,7 +288,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -403,10 +404,9 @@ toml = [
 
 [[package]]
 name = "datalab-api"
-version = "0.2.7.post5+gbd64bf6"
 source = { editable = "." }
 dependencies = [
-    { name = "bokeh" },
+    { name = "bokeh", marker = "sys_platform != 'emscripten'" },
     { name = "httpx" },
     { name = "numpy" },
     { name = "rich" },
@@ -450,7 +450,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bokeh", specifier = "~=2.4" },
+    { name = "bokeh", marker = "sys_platform != 'emscripten'", specifier = "~=2.4" },
     { name = "click-shell", marker = "extra == 'cli'", specifier = "~=2.1" },
     { name = "datalab-api", extras = ["cli", "dev", "docs"], marker = "extra == 'all'" },
     { name = "httpx", specifier = "~=0.27" },
@@ -469,6 +469,7 @@ requires-dist = [
     { name = "rich", specifier = "~=13.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = "~=0.9" },
 ]
+provides-extras = ["dev", "docs", "cli", "cheminventory-helper", "all"]
 
 [[package]]
 name = "debugpy"
@@ -665,7 +666,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -963,7 +964,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },


### PR DESCRIPTION
As part of testing out WASM in https://github.com/datalab-org/datalab-api-wasm-plugin, bokeh cannot be installed by micropip, so we try to prevent its installation when using the emscripten backend.

Plus minor linting and docs updates.