### PR TITLE
Add test for `get_items`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,14 @@ from pytest import fixture
 
 
 @fixture
+def fake_samples_json():
+    """Returns a mocked JSON response for the API /samples endpoint."""
+    return json.loads(
+        '{"status": "success", "samples": [{"chemform": "NaCoO2", "collections": [], "creators": [{"contact_email": null, "display_name": "A. Nother"}], "date": "2025-02-25T14:33:00", "item_id": "test", "name": "", "nblocks": 0, "refcode": "demo:test", "type": "samples"}]}'
+    )
+
+
+@fixture
 def fake_ui_html():
     """Returns a mocked HTML response from the Datalab UI that includes a metadata tag for a fake API URL."""
     return """<!doctype html>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,3 +25,27 @@ def test_redirect_url(fake_ui_html, fake_info_json, fake_block_info_json):
     assert fake_info_api.called
     assert fake_block_info_api.called
     assert client.datalab_api_url == "https://api.datalab.industries"
+
+
+@respx.mock
+def test_sample_list(fake_samples_json, fake_info_json, fake_block_info_json):
+    fake_api = respx.get("https://api.datalab.industries/").mock(
+        return_value=Response(200, content="<!doctype html></html>")
+    )
+    fake_samples_api = respx.get("https://api.datalab.industries/samples").mock(
+        return_value=Response(200, json=fake_samples_json)
+    )
+    fake_info_api = respx.get("https://api.datalab.industries/info").mock(
+        return_value=Response(200, json=fake_info_json)
+    )
+    fake_block_info_api = respx.get("https://api.datalab.industries/info/blocks").mock(
+        return_value=Response(200, json=fake_block_info_json)
+    )
+    with DatalabClient("https://api.datalab.industries") as client:
+        samples = client.get_items(display=True)
+        assert fake_samples_api.called
+        assert fake_api.called
+        assert fake_info_api.called
+        assert fake_block_info_api.called
+        assert len(samples)
+        assert samples[0]["item_id"] == "test"


### PR DESCRIPTION
Simple mocked test that also covers how we output items in tables. Remaining methods that modify the datalab data will be a bit more annoying to deal with.