### PR TITLE
Enable item search by refcode in the API

### DIFF
--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -254,9 +254,11 @@ class DatalabClient(BaseDatalabClient):
             raise ValueError("Must provide only one of `item_id` or `refcode`.")
 
         if refcode is not None:
-            raise NotImplementedError("Searching by `refcode` is not yet implemented.")
+            item_url = f"{self.datalab_api_url}/items/{refcode}"
 
-        item_url = f"{self.datalab_api_url}/get-item-data/{item_id}"
+        else:
+            item_url = f"{self.datalab_api_url}/get-item-data/{item_id}"
+
         item_resp = self.session.get(item_url, follow_redirects=True)
 
         if item_resp.status_code != 200:


### PR DESCRIPTION
Previously the `/items/<refcode>` endpoint was not accessible through the Python API package (as it didn't exist at the time). This PR adds it.