### PR TITLE
Add centralized request error handling to base client class

### DIFF
--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -88,14 +88,14 @@ class DatalabClient(BaseDatalabClient):
         items_url = f"{self.datalab_api_url}/{endpoint_type_map.get(item_type, item_type.replace('_', '-'))}"
         items = self._get(items_url)
 
-        if item_type in items:
-            # Old approach
-            return items[item_type]
-        if "items" in items:
-            return items["items"]
+        if isinstance(items, dict):
+            if item_type in items:
+                # Old approach
+                return items[item_type]
+            if "items" in items:
+                return items["items"]
 
-        else:
-            return items
+        return items  # type: ignore
 
     def search_items(
         self, query: str, item_types: Iterable[str] | str = ("samples", "cells")

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -5,13 +5,9 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from ._base import BaseDatalabClient, __version__
+from ._base import BaseDatalabClient, DuplicateItemError, __version__
 
-__all__ = ("DatalabClient", "__version__")
-
-
-class DuplicateItemError(ValueError):
-    """Raised when the API operation would create a duplicate item."""
+__all__ = ("DatalabClient", "DuplicateItemError", "__version__")
 
 
 class DatalabClient(BaseDatalabClient):

--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -252,6 +252,7 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
             try:
                 error_data = response.json()
                 error_message = error_data.get("message", str(response.content))
+                error_message += f"\nFull JSON: {error_data}"
             except ValueError:
                 error_message = str(response.content)
 
@@ -273,9 +274,10 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
                 if hasattr(self, "_datalab_server_version"):
                     server_info = f" (Server version: {self._datalab_server_version})"
                 raise DatalabAPIError(
-                    f"HTTP 500 Internal Server Error at {url}: {error_message}{server_info}. "
-                    "This is a server-side bug. Please report this issue to the datalab developers "
-                    "at https://github.com/datalab-org/datalab/issues with the full error message."
+                    f"""HTTP 500 Internal Server Error at {url} {server_info}.
+This is likely a server-side bug. Please report this issue to the datalab developers at https://github.com/datalab-org/datalab/issues with the full error message below:
+
+\n{error_message}"""
                 )
             elif response.status_code == 502:
                 raise DatalabAPIError(

--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -306,16 +306,6 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
                 f"Invalid JSON response from {url}: {e}. Response content: {response.content}"
             )
 
-        # Handle API-level status errors
-        if isinstance(data, dict) and data.get("status") != "success":
-            error_message = data.get("message", data.get("status", "Unknown error"))
-
-            # Check for duplicate key errors in the message
-            if "DuplicateKeyError" in error_message:
-                raise DuplicateItemError(f"Duplicate item error at {url}: {error_message}")
-
-            raise DatalabAPIError(f"API error at {url}: {error_message}")
-
         return data
 
     def _request(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,61 @@
 import json
 import os
 
+import respx
+from httpx import Response
 from pytest import fixture
+
+
+@fixture
+def fake_api_url():
+    return "https://api.datalab.industries"
+
+
+@fixture
+def fake_ui_url():
+    return "https://ui.datalab.industries"
+
+
+@fixture
+def mocked_api(
+    fake_api_url,
+    fake_info_json,
+    fake_block_info_json,
+    fake_samples_json,
+    fake_sample_json,
+    fake_collection_json,
+):
+    with respx.mock(base_url=fake_api_url, assert_all_called=False) as respx_mock:
+        fake_api = respx_mock.get("/", name="api")
+        fake_api.return_value = Response(200, content="<!doctype html></html>")
+
+        fake_info_api = respx_mock.get("/info", name="info")
+        fake_info_api.return_value = Response(200, json=fake_info_json)
+
+        fake_block_info_api = respx_mock.get("/info/blocks", name="info-blocks")
+        fake_block_info_api.return_value = Response(200, json=fake_block_info_json)
+
+        fake_samples_api = respx_mock.get("/samples", name="samples")
+        fake_samples_api.return_value = Response(200, json=fake_samples_json)
+
+        fake_item_api = respx_mock.get("/get-item-data/KUVEKJ", name="sample-KUVEKJ")
+        fake_item_api.return_value = Response(200, json=fake_sample_json)
+
+        fake_collection_api = respx_mock.get(
+            "/collections/test_collection", name="collection-test_collection"
+        )
+        fake_collection_api.return_value = Response(200, json=fake_collection_json)
+
+        yield respx_mock
+
+
+@fixture
+def mocked_ui(fake_ui_url, fake_ui_html):
+    with respx.mock(base_url=fake_ui_url, assert_all_called=False) as respx_mock:
+        fake_ui = respx_mock.get("/", name="ui-redirect")
+        fake_ui.return_value = Response(200, content=fake_ui_html)
+
+        yield respx_mock
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,10 +45,25 @@ def mocked_api(
         fake_item_api = respx_mock.get("/get-item-data/KUVEKJ", name="sample-KUVEKJ")
         fake_item_api.return_value = Response(200, json=fake_sample_json)
 
+        fake_missing_item_api = respx_mock.get("/get-item-data/TEST", name="sample-missing-TEST")
+        fake_missing_item_api.return_value = Response(
+            404,
+            json={
+                "message": "No matching items for match={'item_id': 'TEST'} with current authorization",
+                "status": "error",
+            },
+        )
+
         fake_collection_api = respx_mock.get(
             "/collections/test_collection", name="collection-test_collection"
         )
         fake_collection_api.return_value = Response(200, json=fake_collection_json)
+
+        # Fake an unhandled exception
+        fake_internal_error = respx_mock.post("/save-item/", name="bad-save")
+        fake_internal_error.return_value = Response(
+            500, json={"message": "('type',)", "title": "KeyError"}
+        )
 
         yield respx_mock
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ def fake_ui_url():
 @fixture
 def mocked_api(
     fake_api_url,
+    fake_user_json,
     fake_info_json,
     fake_block_info_json,
     fake_samples_json,
@@ -28,6 +29,9 @@ def mocked_api(
     with respx.mock(base_url=fake_api_url, assert_all_called=False) as respx_mock:
         fake_api = respx_mock.get("/", name="api")
         fake_api.return_value = Response(200, content="<!doctype html></html>")
+
+        fake_authentication = respx_mock.get("/get-current-user", name="current_user")
+        fake_authentication.return_value = Response(200, json=fake_user_json)
 
         fake_info_api = respx_mock.get("/info", name="info")
         fake_info_api.return_value = Response(200, json=fake_info_json)
@@ -244,6 +248,35 @@ def fake_block_info_json():
 
     return json.loads(
         '{"data":[{"attributes":{"accepted_file_extensions": [], "description":"Add a rich text comment to the document","name": "Comment", "version": "0.1.0"}, "id": "comment", "type": "block_type"}]}'
+    )
+
+
+@fixture
+def fake_user_json():
+    """Returns a mocked JSON response from the /get-current-user endpoint."""
+
+    return json.loads(
+        """
+{
+  "account_status": "active",
+  "contact_email": null,
+  "display_name": "Jane Doe",
+  "identities": [
+    {
+      "display_name": "Jane Doe",
+      "identifier": "1111111",
+      "identity_type": "github",
+      "name": "jane-doe",
+      "verified": true
+    }
+  ],
+  "immutable_id": "6574f788aabb227db8d1b14e",
+  "last_modified": null,
+  "managers": null,
+  "relationships": null,
+  "role": "user",
+  "type": "people"
+}"""
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,6 +23,9 @@ def test_sample_list(mocked_api, fake_api_url):
         assert mocked_api["info"].called
         assert mocked_api["info-blocks"].called
 
+        client.authenticate()
+        assert mocked_api["current_user"].called
+
         samples = client.get_items(display=True)
         assert mocked_api["samples"].called
         assert len(samples)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ import pytest
 import respx
 
 from datalab_api import DatalabClient
+from datalab_api._base import DatalabAPIError
 
 
 def test_redirect_url(mocked_api, mocked_ui, fake_api_url, fake_ui_url):
@@ -17,7 +18,7 @@ def test_redirect_url(mocked_api, mocked_ui, fake_api_url, fake_ui_url):
     assert client.datalab_api_url == fake_api_url
 
 
-def test_sample_list(mocked_api, fake_api_url):
+def test_sample_operations(mocked_api, fake_api_url):
     with DatalabClient(fake_api_url) as client:
         assert mocked_api["api"].called
         assert mocked_api["info"].called
@@ -34,6 +35,18 @@ def test_sample_list(mocked_api, fake_api_url):
         sample = client.get_item("KUVEKJ", display=True)
         assert mocked_api["sample-KUVEKJ"].called
         assert sample["item_id"] == "KUVEKJ"
+
+        # Check that the full server error message is shown for a missing item
+        with pytest.raises(
+            DatalabAPIError,
+            match="No matching items for match={'item_id': 'TEST'} with current authorization",
+        ):
+            client.get_item("TEST", display=True)
+        assert mocked_api["sample-missing-TEST"].called
+
+        with pytest.raises(DatalabAPIError, match="KeyError"):
+            client.update_item(item_id="TEST", item_data={"name": "test"})
+        assert mocked_api["bad-save"].called
 
 
 @respx.mock

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,81 +1,44 @@
 import pytest
 import respx
-from httpx import Response
 
 from datalab_api import DatalabClient
 
 
-@respx.mock
-def test_redirect_url(fake_ui_html, fake_info_json, fake_block_info_json):
-    fake_ui = respx.get("https://ui.datalab.industries").mock(
-        return_value=Response(200, content=fake_ui_html)
-    )
-    fake_info_api = respx.get("https://api.datalab.industries/info").mock(
-        return_value=Response(200, json=fake_info_json)
-    )
-    fake_block_info_api = respx.get("https://api.datalab.industries/info/blocks").mock(
-        return_value=Response(200, json=fake_block_info_json)
-    )
+def test_redirect_url(mocked_api, mocked_ui, fake_api_url, fake_ui_url):
     with pytest.warns(
         UserWarning,
         match="^Found API URL https://api.datalab.industries in HTML meta tag. Creating client with this URL instead.$",
     ):
-        client = DatalabClient("https://ui.datalab.industries")
-    assert fake_ui.called
-    assert fake_info_api.called
-    assert fake_block_info_api.called
-    assert client.datalab_api_url == "https://api.datalab.industries"
+        client = DatalabClient(fake_ui_url)
+
+    assert mocked_ui["ui-redirect"].called
+    assert mocked_api["info"].called
+    assert mocked_api["info-blocks"].called
+    assert client.datalab_api_url == fake_api_url
 
 
-@respx.mock
-def test_sample_list(fake_samples_json, fake_info_json, fake_sample_json, fake_block_info_json):
-    fake_api = respx.get("https://api.datalab.industries/").mock(
-        return_value=Response(200, content="<!doctype html></html>")
-    )
-    fake_samples_api = respx.get("https://api.datalab.industries/samples").mock(
-        return_value=Response(200, json=fake_samples_json)
-    )
-    fake_info_api = respx.get("https://api.datalab.industries/info").mock(
-        return_value=Response(200, json=fake_info_json)
-    )
-    fake_block_info_api = respx.get("https://api.datalab.industries/info/blocks").mock(
-        return_value=Response(200, json=fake_block_info_json)
-    )
-    fake_item_api = respx.get("https://api.datalab.industries/get-item-data/KUVEKJ").mock(
-        return_value=Response(200, json=fake_sample_json)
-    )
-    with DatalabClient("https://api.datalab.industries") as client:
+def test_sample_list(mocked_api, fake_api_url):
+    with DatalabClient(fake_api_url) as client:
+        assert mocked_api["api"].called
+        assert mocked_api["info"].called
+        assert mocked_api["info-blocks"].called
+
         samples = client.get_items(display=True)
-        assert fake_samples_api.called
-        assert fake_api.called
-        assert fake_info_api.called
-        assert fake_block_info_api.called
+        assert mocked_api["samples"].called
         assert len(samples)
         assert samples[0]["item_id"] == "test"
+
         sample = client.get_item("KUVEKJ", display=True)
-        assert fake_item_api.called
+        assert mocked_api["sample-KUVEKJ"].called
         assert sample["item_id"] == "KUVEKJ"
 
 
 @respx.mock
-def test_collection_get(fake_info_json, fake_block_info_json, fake_collection_json):
-    fake_api = respx.get("https://api.datalab.industries/").mock(
-        return_value=Response(200, content="<!doctype html></html>")
-    )
-    fake_info_api = respx.get("https://api.datalab.industries/info").mock(
-        return_value=Response(200, json=fake_info_json)
-    )
-    fake_block_info_api = respx.get("https://api.datalab.industries/info/blocks").mock(
-        return_value=Response(200, json=fake_block_info_json)
-    )
-
-    fake_collection_api = respx.get(
-        "https://api.datalab.industries/collections/test_collection"
-    ).mock(return_value=Response(200, json=fake_collection_json))
-
+def test_collection_get(fake_api_url, mocked_api):
     with DatalabClient("https://api.datalab.industries") as client:
-        collection, children = client.get_collection("test_collection")
-        assert fake_api.called
-        assert fake_info_api.called
-        assert fake_block_info_api.called
-        assert fake_collection_api.called
+        assert mocked_api["api"].called
+        assert mocked_api["info"].called
+        assert mocked_api["info-blocks"].called
+
+        collection, children = client.get_collection("test_collection", display=True)
+        assert mocked_api["collection-test_collection"].called


### PR DESCRIPTION
This PR centralises request handling into the base class, to allow for much cleaner error reporting. It also refactors tests to use respx_mock as a fixture, and adds several new tests for awkward cases.

Closes #69 