### PR TITLE
Added DatalabAPIError handling for create_item

### DIFF
--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from ._base import BaseDatalabClient, DuplicateItemError, DatalabAPIError, __version__
+from ._base import BaseDatalabClient, DatalabAPIError, DuplicateItemError, __version__
 
 __all__ = ("DatalabClient", "DuplicateItemError", "__version__")
 

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -5,8 +5,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from datalab_api._base import DatalabAPIError
-from ._base import BaseDatalabClient, DuplicateItemError, __version__
+from ._base import BaseDatalabClient, DuplicateItemError, DatalabAPIError, __version__
 
 __all__ = ("DatalabClient", "DuplicateItemError", "__version__")
 

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from datalab_api._base import DatalabAPIError
 from ._base import BaseDatalabClient, DuplicateItemError, __version__
 
 __all__ = ("DatalabClient", "DuplicateItemError", "__version__")
@@ -148,6 +149,9 @@ class DatalabClient(BaseDatalabClient):
             try:
                 collection_immutable_id = self.get_collection(collection_id)[0]["immutable_id"]
             except RuntimeError:
+                self.create_collection(collection_id)
+                collection_immutable_id = self.get_collection(collection_id)[0]["immutable_id"]
+            except DatalabAPIError:
                 self.create_collection(collection_id)
                 collection_immutable_id = self.get_collection(collection_id)[0]["immutable_id"]
             new_item["collections"] = new_item.get("collections", [])


### PR DESCRIPTION
When creating an item while trying to attach it to a collection, which does not exist, the DatalabAPIError is not handled correctly. Adding this specific error to the except options solved the issue and correctly creates a collection to attach the item to.

Traceback:

```bash
resp = client.create_item(item_type=ITEM_TYPE_SAMPLE,item_data=payload, collection_id=collection_id)
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/utils.py", line 20, in rich_wrapper
    result = method(self, *args, **kwargs)
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/__init__.py", line 149, in create_item
    collection_immutable_id = self.get_collection(collection_id)[0]["immutable_id"]
                              ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/utils.py", line 20, in rich_wrapper
    result = method(self, *args, **kwargs)
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/__init__.py", line 421, in get_collection
    collection = self._get(collection_url)
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/utils.py", line 20, in rich_wrapper
    result = method(self, *args, **kwargs)
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/_base.py", line 335, in _get
    return self._request("GET", url, **kwargs)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/utils.py", line 20, in rich_wrapper
    result = method(self, *args, **kwargs)
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/_base.py", line 329, in _request
    return self._handle_response(response, url, expected_status)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/utils.py", line 20, in rich_wrapper
    result = method(self, *args, **kwargs)
  File "~/api_tests/.venv/lib/python3.14/site-packages/datalab_api/_base.py", line 261, in _handle_response
    raise DatalabAPIError(
    ...<2 lines>...
    )
datalab_api._base.DatalabAPIError: HTTP 404 Not Found at http://localhost:5001/collections/Test_Batch: No matching collection collection_id='Test_Batch' with current authorization.
Full JSON: {'message': "No matching collection collection_id='Test_Batch' with current authorization.", 'status': 'error'}. Please check the URL/endpoint is correct and the resource exists.
```