### PR TITLE
Add preliminary support for asynchronous block processing via the API and larger file uploads

### DIFF
--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -403,8 +403,18 @@ class DatalabClient(BaseDatalabClient):
             "save_to_db": True,
         }
 
-        resp = self._post(blocks_url, json=payload)
-        return resp["new_block_data"]
+        resp = self._post(blocks_url, expected_status=[200, 202], json=payload)
+
+        # If block is created synchronously, return the block data
+        if "new_block_data" in resp:
+            return resp["new_block_data"]
+
+        # Otherwise, we return the response which may contain information about the asynchronous block creation process
+        task_id = resp.get("task_id")
+        if task_id:
+            self.triggered_block_task_ids.add(task_id)
+
+        return resp
 
     def get_collection(self, collection_id: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         """Get a collection with a given ID.

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -147,10 +147,7 @@ class DatalabClient(BaseDatalabClient):
         if collection_id is not None:
             try:
                 collection_immutable_id = self.get_collection(collection_id)[0]["immutable_id"]
-            except RuntimeError:
-                self.create_collection(collection_id)
-                collection_immutable_id = self.get_collection(collection_id)[0]["immutable_id"]
-            except DatalabAPIError:
+            except (RuntimeError, DatalabAPIError):
                 self.create_collection(collection_id)
                 collection_immutable_id = self.get_collection(collection_id)[0]["immutable_id"]
             new_item["collections"] = new_item.get("collections", [])

--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -5,6 +5,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Optional, Union
 
+import httpx
+
 from ._base import BaseDatalabClient, DatalabAPIError, DuplicateItemError, __version__
 
 __all__ = ("DatalabClient", "DuplicateItemError", "__version__")
@@ -285,6 +287,10 @@ class DatalabClient(BaseDatalabClient):
         if not file_path.exists():
             raise FileNotFoundError(f"File {file_path=} does not exist.")
 
+        # Use a longer read timeout for uploads, as the server may do
+        # significant processing before responding
+        upload_timeout = httpx.Timeout(self._timeout.connect, read=600.0, pool=self._timeout.pool)
+
         upload_url = f"{self.datalab_api_url}/upload-file/"
         with open(file_path, "rb") as file:
             files = {"file": (file_path.name, file)}
@@ -293,6 +299,7 @@ class DatalabClient(BaseDatalabClient):
                 files=files,
                 data={"item_id": item_id, "replace_file": None},
                 expected_status=201,
+                timeout=upload_timeout,
             )
         return upload
 

--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -360,8 +360,11 @@ This is likely a server-side bug. Please report this issue to the datalab develo
         Returns:
             The JSON response data
         """
+        timeout = kwargs.pop("timeout", None)
         try:
-            response = self.session.request(method, url, follow_redirects=True, **kwargs)
+            response = self.session.request(
+                method, url, follow_redirects=True, timeout=timeout, **kwargs
+            )
             return self._handle_response(response, url, expected_status)
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             raise DatalabAPIError(f"Request failed for {url}: {e}")

--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -4,7 +4,7 @@ import re
 import warnings
 from getpass import getpass
 from importlib.metadata import version
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import httpx
 from rich.logging import RichHandler
@@ -42,6 +42,9 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
     """Whether the client is being used in an interactive context (e.g., CLI or notebook) or not.
     Set to false if you want the script to error if no API key is found in the environment variables,
     rather than prompting for input."""
+
+    triggered_block_task_ids: set[str] = set()
+    """A set of block task IDs that have been triggered during the lifetime of this client instance."""
 
     info: dict[str, Any] = {}
     """The `data` response from the `/info` endpoint of the Datalab API."""
@@ -226,14 +229,14 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
             self._session.close()
 
     def _handle_response(
-        self, response: httpx.Response, url: str, expected_status: int = 200
+        self, response: httpx.Response, url: str, expected_status: Union[int, list[int]] = 200
     ) -> dict[str, Any]:
         """Handle HTTP response with consistent error handling.
 
         Args:
             response: The HTTP response object
             url: The URL that was requested
-            expected_status: The expected HTTP status code (default: 200)
+            expected_status: The expected HTTP status code(s) (default: 200)
 
         Returns:
             The JSON response data
@@ -259,7 +262,10 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
             )
 
         # Handle other HTTP status code errors
-        if response.status_code != expected_status:
+        if isinstance(expected_status, int):
+            expected_status = [expected_status]
+
+        if response.status_code not in expected_status:
             try:
                 error_data = response.json()
                 error_message = error_data.get("message", str(response.content))
@@ -321,8 +327,27 @@ This is likely a server-side bug. Please report this issue to the datalab develo
 
         return data
 
+    def check_tasks(self) -> set[str]:
+        """Check the status of any triggered tasks, returning any that have completed."""
+        if not self.triggered_block_task_ids:
+            return set()
+
+        completed_tasks = set()
+
+        for task_id in self.triggered_block_task_ids:
+            try:
+                response = self._get(f"{self.datalab_api_url}/blocks/{task_id}/status")
+                task_status = response["status"]
+                if task_status == "ready":
+                    self.triggered_block_task_ids.remove(task_id)
+                    completed_tasks.add(task_id)
+            except DatalabAPIError:
+                self.triggered_block_task_ids.remove(task_id)
+
+        return completed_tasks
+
     def _request(
-        self, method: str, url: str, expected_status: int = 200, **kwargs
+        self, method: str, url: str, expected_status: Union[int, list[int]] = 200, **kwargs
     ) -> dict[str, Any]:
         """Make an HTTP request with consistent error handling.
 
@@ -345,7 +370,9 @@ This is likely a server-side bug. Please report this issue to the datalab develo
         """Make a GET request with error handling."""
         return self._request("GET", url, **kwargs)
 
-    def _post(self, url: str, expected_status: int = 200, **kwargs) -> dict[str, Any]:
+    def _post(
+        self, url: str, expected_status: Union[int, list[int]] = 200, **kwargs
+    ) -> dict[str, Any]:
         """Make a POST request with error handling."""
         return self._request("POST", url, expected_status, **kwargs)
 

--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -327,24 +327,24 @@ This is likely a server-side bug. Please report this issue to the datalab develo
 
         return data
 
-    def check_tasks(self) -> set[str]:
+    def check_tasks(self) -> tuple[set[str], set[str]]:
         """Check the status of any triggered tasks, returning any that have completed."""
-        if not self.triggered_block_task_ids:
-            return set()
-
         completed_tasks = set()
+        error_tasks = set()
 
         for task_id in self.triggered_block_task_ids:
             try:
                 response = self._get(f"{self.datalab_api_url}/blocks/{task_id}/status")
                 task_status = response["status"]
                 if task_status == "ready":
-                    self.triggered_block_task_ids.remove(task_id)
                     completed_tasks.add(task_id)
             except DatalabAPIError:
-                self.triggered_block_task_ids.remove(task_id)
+                error_tasks.add(task_id)
 
-        return completed_tasks
+        self.triggered_block_task_ids -= completed_tasks
+        self.triggered_block_task_ids -= error_tasks
+
+        return completed_tasks, error_tasks
 
     def _request(
         self, method: str, url: str, expected_status: Union[int, list[int]] = 200, **kwargs


### PR DESCRIPTION
Adds support for the asynchronous block processing backend added to datalab in v0.7.0-rc.4 by adding a mode that polls for the status of such blocks.

Includes better support for large file uploads with configurable timeout.