### PR TITLE
Switch between legacy `file_id` and `file_ids` field when updating blocks

### DIFF
--- a/src/datalab_api/__init__.py
+++ b/src/datalab_api/__init__.py
@@ -424,10 +424,10 @@ class DatalabClient(BaseDatalabClient):
 
         if file_ids:
             if len(file_ids) > 1:
-                raise RuntimeError(
-                    "API does not currently support attaching multiple files in a block."
-                )
-            block_data["file_id"] = file_ids[0]
+                block_data["file_ids"] = file_ids
+            else:
+                block_data.pop("file_ids", None)
+                block_data["file_id"] = file_ids[0]
 
         blocks_url = f"{self.datalab_api_url}/update-block/"
         payload = {


### PR DESCRIPTION
This PR maintains compatibility with old blocks by only sending the list of multiple file_ids via the `file_ids` parameter, and sending individual files via the "legacy" `file_id` parameter.