### PR TITLE
Changed client header to datalab-python-api

### DIFF
--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -85,7 +85,7 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
         self.log = logging.getLogger(__name__)
 
         self._http_client = httpx.Client
-        self._headers = {"User-Agent": f"Datalab Python API/{__version__}"}
+        self._headers = {"User-Agent": f"datalab-python-api/{__version__}"}
 
         self._detect_api_url()
 


### PR DESCRIPTION
Matches PR from datalab for #[1785](https://github.com/datalab-org/datalab/pull/1785) so the api header matches the known user agents for properly attributing sample creation/modification to the API