### PR TITLE
Self validate against known_user_agents

### DIFF
--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -99,6 +99,21 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
         )
 
         self._find_api_key()
+        self._validate_user_agent()
+
+    def _validate_user_agent(self) -> None:
+        """Warn if this client's User-Agent is not in the server's known agent list."""
+        known_agents = self.info.get("attributes", {}).get("known_user_agents")
+        if not known_agents:
+            return
+        ua = self._headers.get("User-Agent", "")
+        if not any(ua.startswith(agent) for agent in known_agents):
+            warnings.warn(
+                f"User-Agent {ua!r} is not recognised by this datalab server. "
+                f"Versions saved via this client will not be attributed as agent saves. "
+                f"Known agents: {known_agents}",
+                stacklevel=3,
+            )
 
     def _detect_api_url(self) -> None:
         """Perform a handshake with the chosen URL to ascertain the correct API URL.

--- a/src/datalab_api/_base.py
+++ b/src/datalab_api/_base.py
@@ -85,7 +85,7 @@ class BaseDatalabClient(metaclass=AutoPrettyPrint):
         self.log = logging.getLogger(__name__)
 
         self._http_client = httpx.Client
-        self._headers = {"User-Agent": f"Datalab Python API/{__version__}"}
+        self._headers = {"User-Agent": f"datalab-python-api/{__version__}"}
 
         self._detect_api_url()
 


### PR DESCRIPTION
Checks that the api is contained in KNOWN_USER_AGENTS on the datalab server. Raises a warning if not. Requires https://github.com/datalab-org/datalab/pull/1806 to work